### PR TITLE
Made PrefTopKarmaSubreddits nullable

### DIFF
--- a/src/Reddit.NET/Things/User/User.cs
+++ b/src/Reddit.NET/Things/User/User.cs
@@ -123,7 +123,7 @@ namespace Reddit.Things
         public int InboxCount;
 
         [JsonProperty("pref_top_karma_subreddits")]
-        public bool PrefTopKarmaSubreddits;
+        public bool? PrefTopKarmaSubreddits;
 
         [JsonProperty("has_mail")]
         public bool HasMail;


### PR DESCRIPTION
I ran into an issue where the json property "pref_top_karma_subreddits" could return null and returns an invalid cast exception, I fixed this by making the PrefTopKarmaSubreddits property nullable.