### PR TITLE
Use subreddit name instead of PostId for SubKey

### DIFF
--- a/src/Reddit.NET/Controllers/Comments.cs
+++ b/src/Reddit.NET/Controllers/Comments.cs
@@ -365,7 +365,7 @@ namespace Reddit.Controllers
 
             Comment = comment;
 
-            SubKey = (comment?.Fullname != null ? comment.Fullname : "t3_" + PostId);
+            SubKey = comment?.Fullname != null ? comment.Fullname : subreddit;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #98 

Subreddit parameter is always given (unlike PostId):
![image](https://user-images.githubusercontent.com/14852157/72831329-e4c8c780-3c82-11ea-8d92-a381fa3c64dd.png)

SubKey is also only used for monitoring - So making it the subreddit name is unique enough