### PR TITLE
Fix LinksAndComments.Info failing on comments replying to other comments

### DIFF
--- a/src/Reddit.NET/Models/LinksAndComments.cs
+++ b/src/Reddit.NET/Models/LinksAndComments.cs
@@ -171,7 +171,7 @@ namespace Reddit.Models
                         Comment comment = JsonConvert.DeserializeObject<Comment>(JsonConvert.SerializeObject(child.Data));
                         if (loadReplies)
                         {
-                            CommentContainer commentContainer = Common.GetComments(comment.ParentId.Substring(3), new ListingsGetCommentsInput(comment: comment.Id), comment.Subreddit);
+                            CommentContainer commentContainer = Common.GetComments(comment.LinkId.Substring(3), new ListingsGetCommentsInput(comment: comment.Id), comment.Subreddit);
                             if (commentContainer != null
                                 && commentContainer.Data != null
                                 && commentContainer.Data.Children != null

--- a/src/Reddit.NETTests/ModelTests/LinksAndCommentsTests.cs
+++ b/src/Reddit.NETTests/ModelTests/LinksAndCommentsTests.cs
@@ -38,10 +38,12 @@ namespace RedditTests.ModelTests
         {
             string postName = "t3_9nhy54";
             string commentName = "t1_e7s0vb1";
+            string replyCommentName = "t1_csqg24d";
             string subName = "t5_2r5rp";
 
             Info infoLink = reddit.Models.LinksAndComments.Info(postName);
             Info infoComment = reddit.Models.LinksAndComments.Info(commentName);
+            Info infoReply = reddit.Models.LinksAndComments.Info(replyCommentName);
             Info infoLinkCommentSub = reddit.Models.LinksAndComments.Info(postName + "," + commentName + "," + subName);
 
             Assert.IsNotNull(infoLink);
@@ -57,6 +59,13 @@ namespace RedditTests.ModelTests
             Assert.IsTrue(infoComment.Comments.Count == 1);
             Assert.IsTrue(infoComment.Comments[0].Name.Equals(commentName));
             Assert.IsTrue(infoComment.Subreddits.Count == 0);
+
+            Assert.IsNotNull(infoReply);
+            Assert.IsTrue(infoReply.Posts.Count == 0);
+            Assert.IsNotNull(infoReply.Comments);
+            Assert.IsTrue(infoReply.Comments.Count == 1);
+            Assert.IsTrue(infoReply.Comments[0].Name.Equals(replyCommentName));
+            Assert.IsTrue(infoReply.Subreddits.Count == 0);
 
             Assert.IsNotNull(infoLinkCommentSub);
             Assert.IsNotNull(infoLinkCommentSub.Posts);


### PR DESCRIPTION
See issue #114 

This just changes the parent id to the post id.

I also added an example of a reply comment to the Info test. I chose an admin comment that's not likely to be deleted, obviously feel free to change it to something more appropriate lol