### PR TITLE
Modified monitor to be able to accept and pass along options to threads

### DIFF
--- a/src/Reddit.NET/Controllers/Comment.cs
+++ b/src/Reddit.NET/Controllers/Comment.cs
@@ -1259,7 +1259,7 @@ namespace Reddit.Controllers
             }
 
             string key = "CommentScore";
-            return Monitor(key, new Thread(() => MonitorCommentScoreThread(key, monitoringDelayMs)), Id);
+            return Monitor(key, new ThreadWrapper(new Thread(() => MonitorCommentScoreThread(key, monitoringDelayMs))), Id);
         }
 
         /// <summary>
@@ -1283,15 +1283,19 @@ namespace Reddit.Controllers
         /// <param name="subKey">Monitoring subKey</param>
         /// <param name="startDelayMs">How long to wait before starting the thread in milliseconds (default: 0)</param>
         /// <param name="monitoringDelayMs">How long to wait between monitoring queries; pass null to leave it auto-managed (default: null)</param>
+        /// <param name="options">The implementation-specific options</param>
         /// <returns>The newly-created monitoring thread.</returns>
-        protected override Thread CreateMonitoringThread(string key, string subKey, int startDelayMs = 0, int? monitoringDelayMs = null)
+        protected override ThreadWrapper CreateMonitoringThread(string key, string subKey, int startDelayMs = 0,
+            int? monitoringDelayMs = null, object options = null)
         {
             switch (key)
             {
                 default:
                     throw new RedditControllerException("Unrecognized key : " + key + ".");
                   case "CommentScore":
-                    return new Thread(() => MonitorComment(key, "score", subKey, startDelayMs, monitoringDelayMs));
+                      return new ThreadWrapper(new Thread(() =>
+                          MonitorComment(key, "score", subKey, startDelayMs, monitoringDelayMs)), 
+                          options);
             }
         }
 

--- a/src/Reddit.NET/Controllers/Comments.cs
+++ b/src/Reddit.NET/Controllers/Comments.cs
@@ -5,6 +5,7 @@ using Reddit.Exceptions;
 using Reddit.Inputs.Listings;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.SymbolStore;
 using System.Threading;
 
 namespace Reddit.Controllers
@@ -693,9 +694,20 @@ namespace Reddit.Controllers
         /// <param name="breakOnFailure">If true, an exception will be thrown when a monitoring query fails; leave null to keep current setting (default: false)</param>
         /// <param name="monitoringExpiration">If set, monitoring will automatically stop after the specified DateTime is reached</param>
         /// <param name="useCache">Whether to cache the IDs of the monitoring results to prevent duplicate fires (default: true)</param>
+        /// <param name="context">an integer between 0 and 8</param>
+        /// <param name="truncate">an integer between 0 and 50</param>
+        /// <param name="showEdits">boolean value</param>
+        /// <param name="showMore">boolean value</param>
+        /// <param name="threaded">boolean value</param>
+        /// <param name="depth">(optional) an integer</param>
+        /// <param name="limit">(optional) an integer</param>
+        /// <param name="srDetail">(optional) expand subreddits</param>
+        /// <param name="isInterface">(optional) whether to store the result cache in the interface</param>
         /// <returns>True if this action turned monitoring on, false if this action turned it off.</returns>
         public bool MonitorConfidence(int? monitoringDelayMs = null, int? monitoringBaseDelayMs = null, List<MonitoringSchedule> schedule = null, bool? breakOnFailure = null, 
-            DateTime? monitoringExpiration = null, bool useCache = true)
+            DateTime? monitoringExpiration = null, bool useCache = true,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
             if (breakOnFailure.HasValue)
             {
@@ -720,12 +732,39 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "confidence");
 
             string key = "ConfidenceComments";
-            return Monitor(key, new Thread(() => MonitorConfidenceThread(key, monitoringDelayMs)), SubKey);
+            CommentOptions options = BuildOptions(
+                context, truncate, showEdits, showMore,
+                threaded, depth, limit, srDetail, isInterface);
+            return Monitor(key, new ThreadWrapper(
+                    new Thread(() => MonitorConfidenceThread(key, monitoringDelayMs)), 
+                    options), 
+                SubKey);
         }
 
-        private void MonitorConfidenceThread(string key, int? monitoringDelayMs = null)
+        private CommentOptions BuildOptions(int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
-            MonitorCommentsThread(Monitoring, key, "confidence", SubKey, monitoringDelayMs: monitoringDelayMs);
+            return new CommentOptions
+            {
+                Context = context,
+                Truncate = truncate,
+                ShowEdits = showEdits,
+                ShowMore = showMore,
+                Threaded = threaded,
+                Depth = depth,
+                Limit = limit,
+                SrDetail = srDetail,
+                IsInterface = isInterface
+            };
+        }
+
+        private void MonitorConfidenceThread(string key, int? monitoringDelayMs = null,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
+        {
+            MonitorCommentsThread(Monitoring, key, "confidence", SubKey, monitoringDelayMs: monitoringDelayMs,
+                context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface);
         }
 
         internal virtual void OnConfidenceUpdated(CommentsUpdateEventArgs e)
@@ -742,9 +781,20 @@ namespace Reddit.Controllers
         /// <param name="breakOnFailure">If true, an exception will be thrown when a monitoring query fails; leave null to keep current setting (default: false)</param>
         /// <param name="monitoringExpiration">If set, monitoring will automatically stop after the specified DateTime is reached</param>
         /// <param name="useCache">Whether to cache the IDs of the monitoring results to prevent duplicate fires (default: true)</param>
+        /// <param name="context">an integer between 0 and 8</param>
+        /// <param name="truncate">an integer between 0 and 50</param>
+        /// <param name="showEdits">boolean value</param>
+        /// <param name="showMore">boolean value</param>
+        /// <param name="threaded">boolean value</param>
+        /// <param name="depth">(optional) an integer</param>
+        /// <param name="limit">(optional) an integer</param>
+        /// <param name="srDetail">(optional) expand subreddits</param>
+        /// <param name="isInterface">(optional) whether to store the result cache in the interface</param>
         /// <returns>True if this action turned monitoring on, false if this action turned it off.</returns>
         public bool MonitorTop(int? monitoringDelayMs = null, int? monitoringBaseDelayMs = null, List<MonitoringSchedule> schedule = null, bool? breakOnFailure = null,
-            DateTime? monitoringExpiration = null, bool useCache = true)
+            DateTime? monitoringExpiration = null, bool useCache = true,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
             if (breakOnFailure.HasValue)
             {
@@ -769,12 +819,22 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "top");
 
             string key = "TopComments";
-            return Monitor(key, new Thread(() => MonitorTopThread(key, monitoringDelayMs)), SubKey);
+            CommentOptions options = BuildOptions(
+                context, truncate, showEdits, showMore,
+                threaded, depth, limit, srDetail, isInterface);
+            return Monitor(key, new ThreadWrapper(
+                new Thread(() => MonitorTopThread(key, monitoringDelayMs)),
+                options), 
+                SubKey);
         }
 
-        private void MonitorTopThread(string key, int? monitoringDelayMs = null)
+        private void MonitorTopThread(string key, int? monitoringDelayMs = null,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
-            MonitorCommentsThread(Monitoring, key, "top", SubKey, monitoringDelayMs: monitoringDelayMs);
+            MonitorCommentsThread(Monitoring, key, "top", SubKey, monitoringDelayMs: monitoringDelayMs,
+                context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface);
         }
 
         internal virtual void OnTopUpdated(CommentsUpdateEventArgs e)
@@ -791,9 +851,20 @@ namespace Reddit.Controllers
         /// <param name="breakOnFailure">If true, an exception will be thrown when a monitoring query fails; leave null to keep current setting (default: false)</param>
         /// <param name="monitoringExpiration">If set, monitoring will automatically stop after the specified DateTime is reached</param>
         /// <param name="useCache">Whether to cache the IDs of the monitoring results to prevent duplicate fires (default: true)</param>
+        /// <param name="context">an integer between 0 and 8</param>
+        /// <param name="truncate">an integer between 0 and 50</param>
+        /// <param name="showEdits">boolean value</param>
+        /// <param name="showMore">boolean value</param>
+        /// <param name="threaded">boolean value</param>
+        /// <param name="depth">(optional) an integer</param>
+        /// <param name="limit">(optional) an integer</param>
+        /// <param name="srDetail">(optional) expand subreddits</param>
+        /// <param name="isInterface">(optional) whether to store the result cache in the interface</param>
         /// <returns>True if this action turned monitoring on, false if this action turned it off.</returns>
         public bool MonitorNew(int? monitoringDelayMs = null, int? monitoringBaseDelayMs = null, List<MonitoringSchedule> schedule = null, bool? breakOnFailure = null,
-            DateTime? monitoringExpiration = null, bool useCache = true)
+            DateTime? monitoringExpiration = null, bool useCache = true,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
             if (breakOnFailure.HasValue)
             {
@@ -818,12 +889,22 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "new");
 
             string key = "NewComments";
-            return Monitor(key, new Thread(() => MonitorNewThread(key, monitoringDelayMs)), SubKey);
+            CommentOptions options = BuildOptions(
+                context, truncate, showEdits, showMore,
+                threaded, depth, limit, srDetail, isInterface);
+            return Monitor(key, new ThreadWrapper(
+                new Thread(() => MonitorNewThread(key, monitoringDelayMs)),
+                options), 
+                SubKey);
         }
 
-        private void MonitorNewThread(string key, int? monitoringDelayMs = null)
+        private void MonitorNewThread(string key, int? monitoringDelayMs = null,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
-            MonitorCommentsThread(Monitoring, key, "new", SubKey, monitoringDelayMs: monitoringDelayMs);
+            MonitorCommentsThread(Monitoring, key, "new", SubKey, monitoringDelayMs: monitoringDelayMs,
+                context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface);
         }
 
         internal virtual void OnNewUpdated(CommentsUpdateEventArgs e)
@@ -840,9 +921,20 @@ namespace Reddit.Controllers
         /// <param name="breakOnFailure">If true, an exception will be thrown when a monitoring query fails; leave null to keep current setting (default: false)</param>
         /// <param name="monitoringExpiration">If set, monitoring will automatically stop after the specified DateTime is reached</param>
         /// <param name="useCache">Whether to cache the IDs of the monitoring results to prevent duplicate fires (default: true)</param>
+        /// <param name="context">an integer between 0 and 8</param>
+        /// <param name="truncate">an integer between 0 and 50</param>
+        /// <param name="showEdits">boolean value</param>
+        /// <param name="showMore">boolean value</param>
+        /// <param name="threaded">boolean value</param>
+        /// <param name="depth">(optional) an integer</param>
+        /// <param name="limit">(optional) an integer</param>
+        /// <param name="srDetail">(optional) expand subreddits</param>
+        /// <param name="isInterface">(optional) whether to store the result cache in the interface</param>
         /// <returns>True if this action turned monitoring on, false if this action turned it off.</returns>
         public bool MonitorControversial(int? monitoringDelayMs = null, int? monitoringBaseDelayMs = null, List<MonitoringSchedule> schedule = null, bool? breakOnFailure = null,
-            DateTime? monitoringExpiration = null, bool useCache = true)
+            DateTime? monitoringExpiration = null, bool useCache = true,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
             if (breakOnFailure.HasValue)
             {
@@ -867,12 +959,22 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "controversial");
 
             string key = "ControversialComments";
-            return Monitor(key, new Thread(() => MonitorControversialThread(key, monitoringDelayMs)), SubKey);
+            CommentOptions options = BuildOptions(
+                context, truncate, showEdits, showMore,
+                threaded, depth, limit, srDetail, isInterface);
+            return Monitor(key, new ThreadWrapper(
+                new Thread(() => MonitorControversialThread(key, monitoringDelayMs)), 
+                options), 
+                SubKey);
         }
 
-        private void MonitorControversialThread(string key, int? monitoringDelayMs = null)
+        private void MonitorControversialThread(string key, int? monitoringDelayMs = null,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
-            MonitorCommentsThread(Monitoring, key, "controversial", SubKey, monitoringDelayMs: monitoringDelayMs);
+            MonitorCommentsThread(Monitoring, key, "controversial", SubKey, monitoringDelayMs: monitoringDelayMs,
+                context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface);
         }
 
         internal virtual void OnControversialUpdated(CommentsUpdateEventArgs e)
@@ -889,9 +991,20 @@ namespace Reddit.Controllers
         /// <param name="breakOnFailure">If true, an exception will be thrown when a monitoring query fails; leave null to keep current setting (default: false)</param>
         /// <param name="monitoringExpiration">If set, monitoring will automatically stop after the specified DateTime is reached</param>
         /// <param name="useCache">Whether to cache the IDs of the monitoring results to prevent duplicate fires (default: true)</param>
+        /// <param name="context">an integer between 0 and 8</param>
+        /// <param name="truncate">an integer between 0 and 50</param>
+        /// <param name="showEdits">boolean value</param>
+        /// <param name="showMore">boolean value</param>
+        /// <param name="threaded">boolean value</param>
+        /// <param name="depth">(optional) an integer</param>
+        /// <param name="limit">(optional) an integer</param>
+        /// <param name="srDetail">(optional) expand subreddits</param>
+        /// <param name="isInterface">(optional) whether to store the result cache in the interface</param>
         /// <returns>True if this action turned monitoring on, false if this action turned it off.</returns>
         public bool MonitorOld(int? monitoringDelayMs = null, int? monitoringBaseDelayMs = null, List<MonitoringSchedule> schedule = null, bool? breakOnFailure = null,
-            DateTime? monitoringExpiration = null, bool useCache = true)
+            DateTime? monitoringExpiration = null, bool useCache = true,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
             if (breakOnFailure.HasValue)
             {
@@ -916,12 +1029,22 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "old");
 
             string key = "OldComments";
-            return Monitor(key, new Thread(() => MonitorOldThread(key, monitoringDelayMs)), SubKey);
+            CommentOptions options = BuildOptions(
+                context, truncate, showEdits, showMore,
+                threaded, depth, limit, srDetail, isInterface);
+            return Monitor(key, new ThreadWrapper(
+                    new Thread(() => MonitorOldThread(key, monitoringDelayMs)), 
+                    options), 
+                SubKey);
         }
 
-        private void MonitorOldThread(string key, int? monitoringDelayMs = null)
+        private void MonitorOldThread(string key, int? monitoringDelayMs = null,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
-            MonitorCommentsThread(Monitoring, key, "old", SubKey, monitoringDelayMs: monitoringDelayMs);
+            MonitorCommentsThread(Monitoring, key, "old", SubKey, monitoringDelayMs: monitoringDelayMs,
+                context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface);
         }
 
         internal virtual void OnOldUpdated(CommentsUpdateEventArgs e)
@@ -938,9 +1061,20 @@ namespace Reddit.Controllers
         /// <param name="breakOnFailure">If true, an exception will be thrown when a monitoring query fails; leave null to keep current setting (default: false)</param>
         /// <param name="monitoringExpiration">If set, monitoring will automatically stop after the specified DateTime is reached</param>
         /// <param name="useCache">Whether to cache the IDs of the monitoring results to prevent duplicate fires (default: true)</param>
+        /// <param name="context">an integer between 0 and 8</param>
+        /// <param name="truncate">an integer between 0 and 50</param>
+        /// <param name="showEdits">boolean value</param>
+        /// <param name="showMore">boolean value</param>
+        /// <param name="threaded">boolean value</param>
+        /// <param name="depth">(optional) an integer</param>
+        /// <param name="limit">(optional) an integer</param>
+        /// <param name="srDetail">(optional) expand subreddits</param>
+        /// <param name="isInterface">(optional) whether to store the result cache in the interface</param>
         /// <returns>True if this action turned monitoring on, false if this action turned it off.</returns>
         public bool MonitorRandom(int? monitoringDelayMs = null, int? monitoringBaseDelayMs = null, List<MonitoringSchedule> schedule = null, bool? breakOnFailure = null,
-            DateTime? monitoringExpiration = null, bool useCache = true)
+            DateTime? monitoringExpiration = null, bool useCache = true,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
             if (breakOnFailure.HasValue)
             {
@@ -965,12 +1099,22 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "random");
 
             string key = "RandomComments";
-            return Monitor(key, new Thread(() => MonitorRandomThread(key, monitoringDelayMs)), SubKey);
+            CommentOptions options = BuildOptions(
+                context, truncate, showEdits, showMore,
+                threaded, depth, limit, srDetail, isInterface);
+            return Monitor(key, new ThreadWrapper(
+                    new Thread(() => MonitorRandomThread(key, monitoringDelayMs)), 
+                    options), 
+                SubKey);
         }
 
-        private void MonitorRandomThread(string key, int? monitoringDelayMs = null)
+        private void MonitorRandomThread(string key, int? monitoringDelayMs = null,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
-            MonitorCommentsThread(Monitoring, key, "random", SubKey, monitoringDelayMs: monitoringDelayMs);
+            MonitorCommentsThread(Monitoring, key, "random", SubKey, monitoringDelayMs: monitoringDelayMs,
+                context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface);
         }
 
         internal virtual void OnRandomUpdated(CommentsUpdateEventArgs e)
@@ -987,9 +1131,20 @@ namespace Reddit.Controllers
         /// <param name="breakOnFailure">If true, an exception will be thrown when a monitoring query fails; leave null to keep current setting (default: false)</param>
         /// <param name="monitoringExpiration">If set, monitoring will automatically stop after the specified DateTime is reached</param>
         /// <param name="useCache">Whether to cache the IDs of the monitoring results to prevent duplicate fires (default: true)</param>
+        /// <param name="context">an integer between 0 and 8</param>
+        /// <param name="truncate">an integer between 0 and 50</param>
+        /// <param name="showEdits">boolean value</param>
+        /// <param name="showMore">boolean value</param>
+        /// <param name="threaded">boolean value</param>
+        /// <param name="depth">(optional) an integer</param>
+        /// <param name="limit">(optional) an integer</param>
+        /// <param name="srDetail">(optional) expand subreddits</param>
+        /// <param name="isInterface">(optional) whether to store the result cache in the interface</param>
         /// <returns>True if this action turned monitoring on, false if this action turned it off.</returns>
         public bool MonitorQA(int? monitoringDelayMs = null, int? monitoringBaseDelayMs = null, List<MonitoringSchedule> schedule = null, bool? breakOnFailure = null,
-            DateTime? monitoringExpiration = null, bool useCache = true)
+            DateTime? monitoringExpiration = null, bool useCache = true,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
             if (breakOnFailure.HasValue)
             {
@@ -1014,12 +1169,22 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "qa");
 
             string key = "QAComments";
-            return Monitor(key, new Thread(() => MonitorQAThread(key, monitoringDelayMs)), SubKey);
+            CommentOptions options = BuildOptions(
+                context, truncate, showEdits, showMore,
+                threaded, depth, limit, srDetail, isInterface);
+            return Monitor(key, new ThreadWrapper(
+                    new Thread(() => MonitorQAThread(key, monitoringDelayMs)), 
+                    options), 
+                SubKey);
         }
 
-        private void MonitorQAThread(string key, int? monitoringDelayMs = null)
+        private void MonitorQAThread(string key, int? monitoringDelayMs = null,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
-            MonitorCommentsThread(Monitoring, key, "qa", SubKey, monitoringDelayMs: monitoringDelayMs);
+            MonitorCommentsThread(Monitoring, key, "qa", SubKey, monitoringDelayMs: monitoringDelayMs,
+                context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface);
         }
 
         internal virtual void OnQAUpdated(CommentsUpdateEventArgs e)
@@ -1036,9 +1201,20 @@ namespace Reddit.Controllers
         /// <param name="breakOnFailure">If true, an exception will be thrown when a monitoring query fails; leave null to keep current setting (default: false)</param>
         /// <param name="monitoringExpiration">If set, monitoring will automatically stop after the specified DateTime is reached</param>
         /// <param name="useCache">Whether to cache the IDs of the monitoring results to prevent duplicate fires (default: true)</param>
+        /// <param name="context">an integer between 0 and 8</param>
+        /// <param name="truncate">an integer between 0 and 50</param>
+        /// <param name="showEdits">boolean value</param>
+        /// <param name="showMore">boolean value</param>
+        /// <param name="threaded">boolean value</param>
+        /// <param name="depth">(optional) an integer</param>
+        /// <param name="limit">(optional) an integer</param>
+        /// <param name="srDetail">(optional) expand subreddits</param>
+        /// <param name="isInterface">(optional) whether to store the result cache in the interface</param>
         /// <returns>True if this action turned monitoring on, false if this action turned it off.</returns>
         public bool MonitorLive(int? monitoringDelayMs = null, int? monitoringBaseDelayMs = null, List<MonitoringSchedule> schedule = null, bool? breakOnFailure = null,
-            DateTime? monitoringExpiration = null, bool useCache = true)
+            DateTime? monitoringExpiration = null, bool useCache = true,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
             if (breakOnFailure.HasValue)
             {
@@ -1063,12 +1239,22 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "live");
 
             string key = "LiveComments";
-            return Monitor(key, new Thread(() => MonitorLiveThread(key, monitoringDelayMs)), SubKey);
+            CommentOptions options = BuildOptions(
+                context, truncate, showEdits, showMore,
+                threaded, depth, limit, srDetail, isInterface);
+            return Monitor(key, new ThreadWrapper(
+                    new Thread(() => MonitorLiveThread(key, monitoringDelayMs)), 
+                    options), 
+                SubKey);
         }
 
-        private void MonitorLiveThread(string key, int? monitoringDelayMs = null)
+        private void MonitorLiveThread(string key, int? monitoringDelayMs = null,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
-            MonitorCommentsThread(Monitoring, key, "live", SubKey, monitoringDelayMs: monitoringDelayMs);
+            MonitorCommentsThread(Monitoring, key, "live", SubKey, monitoringDelayMs: monitoringDelayMs,
+                context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface);
         }
 
         internal virtual void OnLiveUpdated(CommentsUpdateEventArgs e)
@@ -1076,7 +1262,9 @@ namespace Reddit.Controllers
             LiveUpdated?.Invoke(this, e);
         }
 
-        private void MonitorCommentsThread(MonitoringSnapshot monitoring, string key, string type, string subKey, int startDelayMs = 0, int? monitoringDelayMs = null)
+        private void MonitorCommentsThread(MonitoringSnapshot monitoring, string key, string type, string subKey, int startDelayMs = 0, int? monitoringDelayMs = null,
+            int context = 3, int truncate = 0, bool showEdits = false, bool showMore = true,
+            bool threaded = true, int? depth = null, int? limit = null, bool srDetail = false, bool isInterface = false)
         {
             if (startDelayMs > 0)
             {
@@ -1122,35 +1310,43 @@ namespace Reddit.Controllers
                             throw new RedditControllerException("Unrecognized type '" + type + "'.");
                         case "confidence":
                             oldList = confidence;
-                            newList = GetConfidence();
+                            newList = GetConfidence(context, truncate, showEdits, showMore,
+                                threaded, depth, limit, srDetail, isInterface);
                             break;
                         case "top":
                             oldList = top;
-                            newList = GetTop();
+                            newList = GetTop(context, truncate, showEdits, showMore,
+                                threaded, depth, limit, srDetail, isInterface);
                             break;
                         case "new":
                             oldList = newComments;
-                            newList = GetNew();
+                            newList = GetNew(context, truncate, showEdits, showMore,
+                                threaded, depth, limit, srDetail, isInterface);
                             break;
                         case "controversial":
                             oldList = controversial;
-                            newList = GetControversial();
+                            newList = GetControversial(context, truncate, showEdits, showMore,
+                                threaded, depth, limit, srDetail, isInterface);
                             break;
                         case "old":
                             oldList = old;
-                            newList = GetOld();
+                            newList = GetOld(context, truncate, showEdits, showMore,
+                                threaded, depth, limit, srDetail, isInterface);
                             break;
                         case "random":
                             oldList = random;
-                            newList = GetRandom();
+                            newList = GetRandom(context, truncate, showEdits, showMore,
+                                threaded, depth, limit, srDetail, isInterface);
                             break;
                         case "qa":
                             oldList = qa;
-                            newList = GetQA();
+                            newList = GetQA(context, truncate, showEdits, showMore,
+                                threaded, depth, limit, srDetail, isInterface);
                             break;
                         case "live":
                             oldList = live;
-                            newList = GetLive();
+                            newList = GetLive(context, truncate, showEdits, showMore,
+                                threaded, depth, limit, srDetail, isInterface);
                             break;
                     }
 
@@ -1297,30 +1493,69 @@ namespace Reddit.Controllers
         /// <param name="subKey">Monitoring subKey</param>
         /// <param name="startDelayMs">How long to wait before starting the thread in milliseconds (default: 0)</param>
         /// <param name="monitoringDelayMs">How long to wait between monitoring queries; pass null to leave it auto-managed (default: null)</param>
+        /// <param name="options">The implementation-specific options</param>
         /// <returns>The newly-created monitoring thread.</returns>
-        protected override Thread CreateMonitoringThread(string key, string subKey, int startDelayMs = 0, int? monitoringDelayMs = null)
+        protected override ThreadWrapper CreateMonitoringThread(string key, string subKey, int startDelayMs = 0,
+            int? monitoringDelayMs = null, object options = null)
         {
             switch (key)
             {
                 default:
                     throw new RedditControllerException("Unrecognized key.");
                 case "ConfidenceComments":
-                    return new Thread(() => MonitorCommentsThread(Monitoring, key, "confidence", SubKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(
+                        new Thread(() =>
+                            MonitorCommentsThread(Monitoring, key, "confidence", SubKey, startDelayMs, monitoringDelayMs)),
+                        options);
                 case "TopComments":
-                    return new Thread(() => MonitorCommentsThread(Monitoring, key, "top", SubKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(
+                        new Thread(() =>
+                            MonitorCommentsThread(Monitoring, key, "top", SubKey, startDelayMs, monitoringDelayMs)),
+                        options);
                 case "NewComments":
-                    return new Thread(() => MonitorCommentsThread(Monitoring, key, "new", SubKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(
+                        new Thread(() =>
+                            MonitorCommentsThread(Monitoring, key, "new", SubKey, startDelayMs, monitoringDelayMs)),
+                        options);
                 case "ControversialComments":
-                    return new Thread(() => MonitorCommentsThread(Monitoring, key, "controversial", SubKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(
+                        new Thread(() =>
+                            MonitorCommentsThread(Monitoring, key, "controversial", SubKey, startDelayMs, monitoringDelayMs)),
+                        options);
                 case "OldComments":
-                    return new Thread(() => MonitorCommentsThread(Monitoring, key, "old", SubKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(
+                        new Thread(() =>
+                            MonitorCommentsThread(Monitoring, key, "old", SubKey, startDelayMs, monitoringDelayMs)),
+                        options);
                 case "RandomComments":
-                    return new Thread(() => MonitorCommentsThread(Monitoring, key, "random", SubKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(
+                        new Thread(() =>
+                            MonitorCommentsThread(Monitoring, key, "random", SubKey, startDelayMs, monitoringDelayMs)),
+                        options);
                 case "QAComments":
-                    return new Thread(() => MonitorCommentsThread(Monitoring, key, "qa", SubKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(
+                        new Thread(() =>
+                            MonitorCommentsThread(Monitoring, key, "qa", SubKey, startDelayMs, monitoringDelayMs)),
+                        options);
                 case "LiveComments":
-                    return new Thread(() => MonitorCommentsThread(Monitoring, key, "live", SubKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(
+                        new Thread(() =>
+                            MonitorCommentsThread(Monitoring, key, "live", SubKey, startDelayMs, monitoringDelayMs)),
+                        options);
             }
+        }
+
+        private class CommentOptions
+        {
+            public int Context { get; set; } = 3;
+            public int Truncate { get; set; } = 0;
+            public bool ShowEdits { get; set; } = false;
+            public bool ShowMore { get; set; } = true;
+            public bool Threaded { get; set; } = true;
+            public int? Depth { get; set; } = null;
+            public int? Limit { get; set; } = null;
+            public bool SrDetail { get; set; } = false;
+            public bool IsInterface { get; set; } = false;
         }
     }
 }

--- a/src/Reddit.NET/Controllers/Comments.cs
+++ b/src/Reddit.NET/Controllers/Comments.cs
@@ -1498,51 +1498,30 @@ namespace Reddit.Controllers
         protected override ThreadWrapper CreateMonitoringThread(string key, string subKey, int startDelayMs = 0,
             int? monitoringDelayMs = null, object options = null)
         {
-            switch (key)
+            CommentOptions opts = CommentOptions.GetOptionsOrDefault(options);
+            
+            string keyTranslation = "";
+            Dictionary<string, string> lookups = new Dictionary<string, string>
             {
-                default:
-                    throw new RedditControllerException("Unrecognized key.");
-                case "ConfidenceComments":
-                    return new ThreadWrapper(
-                        new Thread(() =>
-                            MonitorCommentsThread(Monitoring, key, "confidence", SubKey, startDelayMs, monitoringDelayMs)),
-                        options);
-                case "TopComments":
-                    return new ThreadWrapper(
-                        new Thread(() =>
-                            MonitorCommentsThread(Monitoring, key, "top", SubKey, startDelayMs, monitoringDelayMs)),
-                        options);
-                case "NewComments":
-                    return new ThreadWrapper(
-                        new Thread(() =>
-                            MonitorCommentsThread(Monitoring, key, "new", SubKey, startDelayMs, monitoringDelayMs)),
-                        options);
-                case "ControversialComments":
-                    return new ThreadWrapper(
-                        new Thread(() =>
-                            MonitorCommentsThread(Monitoring, key, "controversial", SubKey, startDelayMs, monitoringDelayMs)),
-                        options);
-                case "OldComments":
-                    return new ThreadWrapper(
-                        new Thread(() =>
-                            MonitorCommentsThread(Monitoring, key, "old", SubKey, startDelayMs, monitoringDelayMs)),
-                        options);
-                case "RandomComments":
-                    return new ThreadWrapper(
-                        new Thread(() =>
-                            MonitorCommentsThread(Monitoring, key, "random", SubKey, startDelayMs, monitoringDelayMs)),
-                        options);
-                case "QAComments":
-                    return new ThreadWrapper(
-                        new Thread(() =>
-                            MonitorCommentsThread(Monitoring, key, "qa", SubKey, startDelayMs, monitoringDelayMs)),
-                        options);
-                case "LiveComments":
-                    return new ThreadWrapper(
-                        new Thread(() =>
-                            MonitorCommentsThread(Monitoring, key, "live", SubKey, startDelayMs, monitoringDelayMs)),
-                        options);
-            }
+                ["ConfidenceComments"] = "confidence",
+                ["TopComments"] = "top",
+                ["NewComments"] = "new",
+                ["ControversialComments"] = "controversial",
+                ["OldComments"] = "old",
+                ["RandomComments"] = "random",
+                ["QAComments"] = "qa",
+                ["LiveComments"] = "live"
+            };
+            
+            if (!lookups.ContainsKey(key)) 
+                throw new RedditControllerException("Unrecognized key.");
+
+            return new ThreadWrapper(
+                new Thread(() =>
+                    MonitorCommentsThread(Monitoring, key, keyTranslation, SubKey, startDelayMs, monitoringDelayMs,
+                        opts.Context, opts.Truncate, opts.ShowEdits, opts.ShowMore,
+                        opts.Threaded, opts.Depth, opts.Limit, opts.SrDetail, opts.IsInterface)),
+                options);
         }
 
         private class CommentOptions
@@ -1556,6 +1535,13 @@ namespace Reddit.Controllers
             public int? Limit { get; set; } = null;
             public bool SrDetail { get; set; } = false;
             public bool IsInterface { get; set; } = false;
+
+            public static CommentOptions GetOptionsOrDefault(object options)
+            {
+                CommentOptions castedOptions = options as CommentOptions;
+
+                return castedOptions ?? new CommentOptions();
+            }
         }
     }
 }

--- a/src/Reddit.NET/Controllers/Comments.cs
+++ b/src/Reddit.NET/Controllers/Comments.cs
@@ -736,7 +736,9 @@ namespace Reddit.Controllers
                 context, truncate, showEdits, showMore,
                 threaded, depth, limit, srDetail, isInterface);
             return Monitor(key, new ThreadWrapper(
-                    new Thread(() => MonitorConfidenceThread(key, monitoringDelayMs)), 
+                    new Thread(() => MonitorConfidenceThread(key, monitoringDelayMs,
+                        context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                        threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface)), 
                     options), 
                 SubKey);
         }
@@ -823,7 +825,9 @@ namespace Reddit.Controllers
                 context, truncate, showEdits, showMore,
                 threaded, depth, limit, srDetail, isInterface);
             return Monitor(key, new ThreadWrapper(
-                new Thread(() => MonitorTopThread(key, monitoringDelayMs)),
+                new Thread(() => MonitorTopThread(key, monitoringDelayMs,
+                    context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                    threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface)),
                 options), 
                 SubKey);
         }
@@ -893,7 +897,9 @@ namespace Reddit.Controllers
                 context, truncate, showEdits, showMore,
                 threaded, depth, limit, srDetail, isInterface);
             return Monitor(key, new ThreadWrapper(
-                new Thread(() => MonitorNewThread(key, monitoringDelayMs)),
+                new Thread(() => MonitorNewThread(key, monitoringDelayMs,
+                    context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                    threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface)),
                 options), 
                 SubKey);
         }
@@ -963,7 +969,9 @@ namespace Reddit.Controllers
                 context, truncate, showEdits, showMore,
                 threaded, depth, limit, srDetail, isInterface);
             return Monitor(key, new ThreadWrapper(
-                new Thread(() => MonitorControversialThread(key, monitoringDelayMs)), 
+                new Thread(() => MonitorControversialThread(key, monitoringDelayMs,
+                    context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                    threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface)), 
                 options), 
                 SubKey);
         }
@@ -1033,7 +1041,9 @@ namespace Reddit.Controllers
                 context, truncate, showEdits, showMore,
                 threaded, depth, limit, srDetail, isInterface);
             return Monitor(key, new ThreadWrapper(
-                    new Thread(() => MonitorOldThread(key, monitoringDelayMs)), 
+                    new Thread(() => MonitorOldThread(key, monitoringDelayMs,
+                        context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                        threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface)), 
                     options), 
                 SubKey);
         }
@@ -1103,7 +1113,9 @@ namespace Reddit.Controllers
                 context, truncate, showEdits, showMore,
                 threaded, depth, limit, srDetail, isInterface);
             return Monitor(key, new ThreadWrapper(
-                    new Thread(() => MonitorRandomThread(key, monitoringDelayMs)), 
+                    new Thread(() => MonitorRandomThread(key, monitoringDelayMs,
+                        context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                        threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface)), 
                     options), 
                 SubKey);
         }
@@ -1173,7 +1185,9 @@ namespace Reddit.Controllers
                 context, truncate, showEdits, showMore,
                 threaded, depth, limit, srDetail, isInterface);
             return Monitor(key, new ThreadWrapper(
-                    new Thread(() => MonitorQAThread(key, monitoringDelayMs)), 
+                    new Thread(() => MonitorQAThread(key, monitoringDelayMs,
+                        context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                        threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface)), 
                     options), 
                 SubKey);
         }
@@ -1243,7 +1257,9 @@ namespace Reddit.Controllers
                 context, truncate, showEdits, showMore,
                 threaded, depth, limit, srDetail, isInterface);
             return Monitor(key, new ThreadWrapper(
-                    new Thread(() => MonitorLiveThread(key, monitoringDelayMs)), 
+                    new Thread(() => MonitorLiveThread(key, monitoringDelayMs,
+                        context: context, truncate: truncate, showEdits: showEdits, showMore:showMore,
+                        threaded: threaded, depth: depth, limit: limit, srDetail: srDetail, isInterface: isInterface)), 
                     options), 
                 SubKey);
         }

--- a/src/Reddit.NET/Controllers/Internal/ThreadWrapper.cs
+++ b/src/Reddit.NET/Controllers/Internal/ThreadWrapper.cs
@@ -1,0 +1,32 @@
+﻿// TedCruzResponderBot - Simple real-time chat application.
+// Copyright (C) 2021  Jerrett D. Davis
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+using System.Threading;
+
+namespace Reddit.Controllers.Internal
+{
+    public class ThreadWrapper
+    {
+        public ThreadWrapper(Thread thread, object options = null)
+        {
+            Thread = thread;
+            Options = options;
+        }
+
+        public Thread Thread { get; }
+        public object Options { get; }
+    }
+}

--- a/src/Reddit.NET/Controllers/LiveThread.cs
+++ b/src/Reddit.NET/Controllers/LiveThread.cs
@@ -912,7 +912,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "thread");
 
             string key = "LiveThread";
-            return Monitor(key, new Thread(() => MonitorThreadThread(key, monitoringDelayMs)), Id);
+            return Monitor(key, new ThreadWrapper(new Thread(() => MonitorThreadThread(key, monitoringDelayMs))), Id);
         }
 
         /// <summary>
@@ -951,7 +951,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "contributors");
 
             string key = "LiveThreadContributors";
-            return Monitor(key, new Thread(() => MonitorContributorsThread(key, monitoringDelayMs)), Id);
+            return Monitor(key, new ThreadWrapper(new Thread(() => MonitorContributorsThread(key, monitoringDelayMs))), Id);
         }
 
         /// <summary>
@@ -990,7 +990,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "updates");
 
             string key = "LiveThreadUpdates";
-            return Monitor(key, new Thread(() => MonitorUpdatesThread(key, monitoringDelayMs)), Id);
+            return Monitor(key, new ThreadWrapper(new Thread(() => MonitorUpdatesThread(key, monitoringDelayMs))), Id);
         }
 
         public bool LiveThreadIsMonitored()
@@ -1008,18 +1008,28 @@ namespace Reddit.Controllers
             return IsMonitored("LiveThreadUpdates", "updates");
         }
 
-        protected override Thread CreateMonitoringThread(string key, string subKey, int startDelayMs = 0, int? monitoringDelayMs = null)
+        /// <summary>
+        /// Creates a new monitoring thread.
+        /// </summary>
+        /// <param name="key">Monitoring key</param>
+        /// <param name="subKey">Monitoring subKey</param>
+        /// <param name="startDelayMs">How long to wait before starting the thread in milliseconds (default: 0)</param>
+        /// <param name="monitoringDelayMs">How long to wait between monitoring queries; pass null to leave it auto-managed (default: null)</param>
+        /// <param name="options">The implementation-specific options</param>
+        /// <returns>The newly-created monitoring thread.</returns>
+        protected override ThreadWrapper CreateMonitoringThread(string key, string subKey, int startDelayMs = 0,
+            int? monitoringDelayMs = null, object options = null)
         {
             switch (key)
             {
                 default:
                     throw new RedditControllerException("Unrecognized key.");
                 case "LiveThread":
-                    return new Thread(() => MonitorLiveThread(key, "thread", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorLiveThread(key, "thread", subKey, startDelayMs, monitoringDelayMs)));
                 case "LiveThreadContributors":
-                    return new Thread(() => MonitorLiveThread(key, "contributors", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorLiveThread(key, "contributors", subKey, startDelayMs, monitoringDelayMs)));
                 case "LiveThreadUpdates":
-                    return new Thread(() => MonitorLiveThread(key, "updates", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorLiveThread(key, "updates", subKey, startDelayMs, monitoringDelayMs)));
             }
         }
 

--- a/src/Reddit.NET/Controllers/Modmail.cs
+++ b/src/Reddit.NET/Controllers/Modmail.cs
@@ -637,7 +637,9 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "recent");
 
             string key = "ModmailMessagesRecent";
-            return Monitor(key, new Thread(() => MonitorModmailMessagesThread(recent, key, "recent", monitoringDelayMs: monitoringDelayMs)), "ModmailMessages");
+            return Monitor(key, new ThreadWrapper(
+                new Thread(() => MonitorModmailMessagesThread(recent, key, "recent", monitoringDelayMs: monitoringDelayMs)))
+                , "ModmailMessages");
         }
 
         /// <summary>
@@ -676,7 +678,9 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "mod");
 
             string key = "ModmailMessagesMod";
-            return Monitor(key, new Thread(() => MonitorModmailMessagesThread(mod, key, "mod", monitoringDelayMs: monitoringDelayMs)), "ModmailMessages");
+            return Monitor(key, 
+                new ThreadWrapper(new Thread(() => MonitorModmailMessagesThread(mod, key, "mod", monitoringDelayMs: monitoringDelayMs))), 
+                "ModmailMessages");
         }
 
         /// <summary>
@@ -715,7 +719,9 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "user");
 
             string key = "ModmailMessagesUser";
-            return Monitor(key, new Thread(() => MonitorModmailMessagesThread(user, key, "user", monitoringDelayMs: monitoringDelayMs)), "ModmailMessages");
+            return Monitor(key, 
+                new ThreadWrapper(new Thread(() => MonitorModmailMessagesThread(user, key, "user", monitoringDelayMs: monitoringDelayMs))), 
+                "ModmailMessages");
         }
 
         /// <summary>
@@ -754,7 +760,9 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "unread");
 
             string key = "ModmailMessagesUnread";
-            return Monitor(key, new Thread(() => MonitorModmailMessagesThread(unread, key, "unread", monitoringDelayMs: monitoringDelayMs)), "ModmailMessages");
+            return Monitor(key, 
+                new ThreadWrapper(new Thread(() => MonitorModmailMessagesThread(unread, key, "unread", monitoringDelayMs: monitoringDelayMs))), 
+                "ModmailMessages");
         }
 
         /// <summary>
@@ -992,21 +1000,23 @@ namespace Reddit.Controllers
         /// <param name="subKey">Monitoring subKey</param>
         /// <param name="startDelayMs">How long to wait before starting the thread in milliseconds (default: 0)</param>
         /// <param name="monitoringDelayMs">How long to wait between monitoring queries; pass null to leave it auto-managed (default: null)</param>
+        /// <param name="options">The implementation-specific options</param>
         /// <returns>The newly-created monitoring thread.</returns>
-        protected override Thread CreateMonitoringThread(string key, string subKey, int startDelayMs = 0, int? monitoringDelayMs = null)
+        protected override ThreadWrapper CreateMonitoringThread(string key, string subKey, int startDelayMs = 0,
+            int? monitoringDelayMs = null, object options = null)
         {
             switch (key)
             {
                 default:
                     throw new RedditControllerException("Unrecognized key.");
                 case "ModmailMessagesRecent":
-                    return new Thread(() => MonitorModmailMessagesThread(recent, key, "recent", startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorModmailMessagesThread(recent, key, "recent", startDelayMs, monitoringDelayMs)),options);
                 case "ModmailMessagesMod":
-                    return new Thread(() => MonitorModmailMessagesThread(mod, key, "mod", startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorModmailMessagesThread(mod, key, "mod", startDelayMs, monitoringDelayMs)),options);
                 case "ModmailMessagesUser":
-                    return new Thread(() => MonitorModmailMessagesThread(user, key, "user", startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorModmailMessagesThread(user, key, "user", startDelayMs, monitoringDelayMs)),options);
                 case "ModmailMessagesUnread":
-                    return new Thread(() => MonitorModmailMessagesThread(unread, key, "unread", startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorModmailMessagesThread(unread, key, "unread", startDelayMs, monitoringDelayMs)),options);
             }
         }
     }

--- a/src/Reddit.NET/Controllers/Post.cs
+++ b/src/Reddit.NET/Controllers/Post.cs
@@ -1305,7 +1305,8 @@ namespace Reddit.Controllers
             }
 
             string key = "PostData";
-            return Monitor(key, new Thread(() => MonitorPostDataThread(key, monitoringDelayMs)), Id);
+            return Monitor(key, new ThreadWrapper( 
+                new Thread(() => MonitorPostDataThread(key, monitoringDelayMs))), Id);
         }
 
         /// <summary>
@@ -1364,7 +1365,8 @@ namespace Reddit.Controllers
             }
 
             string key = "PostScore";
-            return Monitor(key, new Thread(() => MonitorPostScoreThread(key, monitoringDelayMs)), Id);
+            return Monitor(key, new ThreadWrapper( 
+                new Thread(() => MonitorPostScoreThread(key, monitoringDelayMs))), Id);
         }
 
         /// <summary>
@@ -1402,17 +1404,21 @@ namespace Reddit.Controllers
         /// <param name="subKey">Monitoring subKey</param>
         /// <param name="startDelayMs">How long to wait before starting the thread in milliseconds (default: 0)</param>
         /// <param name="monitoringDelayMs">How long to wait between monitoring queries; pass null to leave it auto-managed (default: null)</param>
+        /// <param name="options">The implementation-specific options</param>
         /// <returns>The newly-created monitoring thread.</returns>
-        protected override Thread CreateMonitoringThread(string key, string subKey, int startDelayMs = 0, int? monitoringDelayMs = null)
+        protected override ThreadWrapper CreateMonitoringThread(string key, string subKey, int startDelayMs = 0,
+            int? monitoringDelayMs = null, object options = null)
         {
             switch (key)
             {
                 default:
                     throw new RedditControllerException("Unrecognized key : " + key + ".");
                 case "PostData":
-                    return new Thread(() => MonitorPost(key, "data", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(
+                        new Thread(() => MonitorPost(key, "data", subKey, startDelayMs, monitoringDelayMs)), options);
                 case "PostScore":
-                    return new Thread(() => MonitorPost(key, "score", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(
+                        new Thread(() => MonitorPost(key, "score", subKey, startDelayMs, monitoringDelayMs)), options);
             }
         }
 

--- a/src/Reddit.NET/Controllers/PrivateMessages.cs
+++ b/src/Reddit.NET/Controllers/PrivateMessages.cs
@@ -111,7 +111,7 @@ namespace Reddit.Controllers
             Unread = unread ?? new List<Message>();
             Sent = sent ?? new List<Message>();
 
-            Threads = new Dictionary<string, Thread>();
+            Threads = new Dictionary<string, ThreadWrapper>();
 
             Dispatch = dispatch;
 
@@ -478,7 +478,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "inbox");
 
             string key = "PrivateMessagesInbox";
-            return Monitor(key, new Thread(() => MonitorInboxThread(key, monitoringDelayMs)), "PrivateMessages");
+            return Monitor(key, new ThreadWrapper(new Thread(() => MonitorInboxThread(key, monitoringDelayMs))), "PrivateMessages");
         }
 
         private void MonitorInboxThread(string key, int? monitoringDelayMs = null)
@@ -522,7 +522,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "unread");
 
             string key = "PrivateMessagesUnread";
-            return Monitor(key, new Thread(() => MonitorUnreadThread(key, monitoringDelayMs)), "PrivateMessages");
+            return Monitor(key, new ThreadWrapper(new Thread(() => MonitorUnreadThread(key, monitoringDelayMs))), "PrivateMessages");
         }
 
         private void MonitorUnreadThread(string key, int? monitoringDelayMs = null)
@@ -566,7 +566,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "sent");
 
             string key = "PrivateMessagesSent";
-            return Monitor(key, new Thread(() => MonitorSentThread(key, monitoringDelayMs)), "PrivateMessages");
+            return Monitor(key, new ThreadWrapper(new Thread(() => MonitorSentThread(key, monitoringDelayMs))), "PrivateMessages");
         }
 
         private void MonitorSentThread(string key, int? monitoringDelayMs = null)
@@ -715,19 +715,21 @@ namespace Reddit.Controllers
         /// <param name="subKey">Monitoring subKey</param>
         /// <param name="startDelayMs">How long to wait before starting the thread in milliseconds (default: 0)</param>
         /// <param name="monitoringDelayMs">How long to wait between monitoring queries; pass null to leave it auto-managed (default: null)</param>
+        /// <param name="options">The implementation-specific options</param>
         /// <returns>The newly-created monitoring thread.</returns>
-        protected override Thread CreateMonitoringThread(string key, string subKey, int startDelayMs = 0, int? monitoringDelayMs = null)
+        protected override ThreadWrapper CreateMonitoringThread(string key, string subKey, int startDelayMs = 0,
+            int? monitoringDelayMs = null, object options = null)
         {
             switch (key)
             {
                 default:
                     throw new RedditControllerException("Unrecognized key.");
                 case "PrivateMessagesInbox":
-                    return new Thread(() => MonitorPrivateMessagesThread(key, "inbox", startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPrivateMessagesThread(key, "inbox", startDelayMs, monitoringDelayMs)), options);
                 case "PrivateMessagesUnread":
-                    return new Thread(() => MonitorPrivateMessagesThread(key, "unread", startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPrivateMessagesThread(key, "unread", startDelayMs, monitoringDelayMs)), options);
                 case "PrivateMessagesSent":
-                    return new Thread(() => MonitorPrivateMessagesThread(key, "sent", startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPrivateMessagesThread(key, "sent", startDelayMs, monitoringDelayMs)),options);
             }
         }
     }

--- a/src/Reddit.NET/Controllers/SubredditPosts.cs
+++ b/src/Reddit.NET/Controllers/SubredditPosts.cs
@@ -930,7 +930,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "best");
 
             string key = "BestPosts";
-            return Monitor(key, new Thread(() => MonitorBestThread(key, monitoringDelayMs)), Subreddit);
+            return Monitor(key,  new ThreadWrapper(new Thread(() => MonitorBestThread(key, monitoringDelayMs))), Subreddit);
         }
 
         private void MonitorBestThread(string key, int? monitoringDelayMs = null, bool? breakOnFailure = null)
@@ -979,7 +979,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "hot");
 
             string key = "HotPosts";
-            return Monitor(key, new Thread(() => MonitorHotThread(key, monitoringDelayMs)), Subreddit);
+            return Monitor(key,  new ThreadWrapper(new Thread(() => MonitorHotThread(key, monitoringDelayMs))), Subreddit);
         }
 
         private void MonitorHotThread(string key, int? monitoringDelayMs = null)
@@ -1028,7 +1028,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "new");
 
             string key = "NewPosts";
-            return Monitor(key, new Thread(() => MonitorNewThread(key, monitoringDelayMs)), Subreddit);
+            return Monitor(key,  new ThreadWrapper(new Thread(() => MonitorNewThread(key, monitoringDelayMs))), Subreddit);
         }
 
         private void MonitorNewThread(string key, int? monitoringDelayMs = null)
@@ -1077,7 +1077,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "rising");
 
             string key = "RisingPosts";
-            return Monitor(key, new Thread(() => MonitorRisingThread(key, monitoringDelayMs)), Subreddit);
+            return Monitor(key,  new ThreadWrapper(new Thread(() => MonitorRisingThread(key, monitoringDelayMs))), Subreddit);
         }
 
         private void MonitorRisingThread(string key, int? monitoringDelayMs = null)
@@ -1126,7 +1126,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "top");
 
             string key = "TopPosts";
-            return Monitor(key, new Thread(() => MonitorTopThread(key, monitoringDelayMs)), Subreddit);
+            return Monitor(key,  new ThreadWrapper(new Thread(() => MonitorTopThread(key, monitoringDelayMs))), Subreddit);
         }
 
         private void MonitorTopThread(string key, int? monitoringDelayMs = null)
@@ -1175,7 +1175,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "controversial");
 
             string key = "ControversialPosts";
-            return Monitor(key, new Thread(() => MonitorControversialThread(key, monitoringDelayMs)), Subreddit);
+            return Monitor(key,  new ThreadWrapper(new Thread(() => MonitorControversialThread(key, monitoringDelayMs))), Subreddit);
         }
 
         private void MonitorControversialThread(string key, int? monitoringDelayMs = null)
@@ -1224,7 +1224,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "modqueue");
 
             string key = "ModQueuePosts";
-            return Monitor(key, new Thread(() => MonitorModQueueThread(key, monitoringDelayMs)), Subreddit);
+            return Monitor(key,  new ThreadWrapper(new Thread(() => MonitorModQueueThread(key, monitoringDelayMs))), Subreddit);
         }
 
         private void MonitorModQueueThread(string key, int? monitoringDelayMs = null)
@@ -1273,7 +1273,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "modqueuereports");
 
             string key = "ModQueueReportsPosts";
-            return Monitor(key, new Thread(() => MonitorModQueueReportsThread(key, monitoringDelayMs)), Subreddit);
+            return Monitor(key,  new ThreadWrapper(new Thread(() => MonitorModQueueReportsThread(key, monitoringDelayMs))), Subreddit);
         }
 
         private void MonitorModQueueReportsThread(string key, int? monitoringDelayMs = null)
@@ -1322,7 +1322,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "modqueuespam");
 
             string key = "ModQueueSpamPosts";
-            return Monitor(key, new Thread(() => MonitorModQueueSpamThread(key, monitoringDelayMs)), Subreddit);
+            return Monitor(key,  new ThreadWrapper(new Thread(() => MonitorModQueueSpamThread(key, monitoringDelayMs))), Subreddit);
         }
 
         private void MonitorModQueueSpamThread(string key, int? monitoringDelayMs = null)
@@ -1371,7 +1371,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "modqueueunmoderated");
 
             string key = "ModQueueUnmoderatedPosts";
-            return Monitor(key, new Thread(() => MonitorModQueueUnmoderatedThread(key, monitoringDelayMs)), Subreddit);
+            return Monitor(key,  new ThreadWrapper(new Thread(() => MonitorModQueueUnmoderatedThread(key, monitoringDelayMs))), Subreddit);
         }
 
         private void MonitorModQueueUnmoderatedThread(string key, int? monitoringDelayMs = null)
@@ -1420,7 +1420,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "modqueueedited");
 
             string key = "ModQueueEditedPosts";
-            return Monitor(key, new Thread(() => MonitorModQueueEditedThread(key, monitoringDelayMs)), Subreddit);
+            return Monitor(key, new ThreadWrapper(new Thread(() => MonitorModQueueEditedThread(key, monitoringDelayMs))), Subreddit);
         }
 
         private void MonitorModQueueEditedThread(string key, int? monitoringDelayMs = null)
@@ -1539,35 +1539,37 @@ namespace Reddit.Controllers
         /// <param name="subKey">Monitoring subKey</param>
         /// <param name="startDelayMs">How long to wait before starting the thread in milliseconds (default: 0)</param>
         /// <param name="monitoringDelayMs">How long to wait between monitoring queries; pass null to leave it auto-managed (default: null)</param>
+        /// <param name="options">The implementation-specific options</param>
         /// <returns>The newly-created monitoring thread.</returns>
-        protected override Thread CreateMonitoringThread(string key, string subKey, int startDelayMs = 0, int? monitoringDelayMs = null)
+        protected override ThreadWrapper CreateMonitoringThread(string key, string subKey, int startDelayMs = 0,
+            int? monitoringDelayMs = null, object options = null)
         {
             switch (key)
             {
                 default:
                     throw new RedditControllerException("Unrecognized key.");
                 case "BestPosts":
-                    return new Thread(() => MonitorPostsThread(Monitoring, key, "best", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPostsThread(Monitoring, key, "best", subKey, startDelayMs, monitoringDelayMs)), options);
                 case "HotPosts":
-                    return new Thread(() => MonitorPostsThread(Monitoring, key, "hot", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPostsThread(Monitoring, key, "hot", subKey, startDelayMs, monitoringDelayMs)), options);
                 case "NewPosts":
-                    return new Thread(() => MonitorPostsThread(Monitoring, key, "new", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPostsThread(Monitoring, key, "new", subKey, startDelayMs, monitoringDelayMs)), options);
                 case "RisingPosts":
-                    return new Thread(() => MonitorPostsThread(Monitoring, key, "rising", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPostsThread(Monitoring, key, "rising", subKey, startDelayMs, monitoringDelayMs)), options);
                 case "TopPosts":
-                    return new Thread(() => MonitorPostsThread(Monitoring, key, "top", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPostsThread(Monitoring, key, "top", subKey, startDelayMs, monitoringDelayMs)), options);
                 case "ControversialPosts":
-                    return new Thread(() => MonitorPostsThread(Monitoring, key, "controversial", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPostsThread(Monitoring, key, "controversial", subKey, startDelayMs, monitoringDelayMs)), options);
                 case "ModQueuePosts":
-                    return new Thread(() => MonitorPostsThread(Monitoring, key, "modqueue", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPostsThread(Monitoring, key, "modqueue", subKey, startDelayMs, monitoringDelayMs)), options);
                 case "ModQueueReportsPosts":
-                    return new Thread(() => MonitorPostsThread(Monitoring, key, "modqueuereports", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPostsThread(Monitoring, key, "modqueuereports", subKey, startDelayMs, monitoringDelayMs)), options);
                 case "ModQueueSpamPosts":
-                    return new Thread(() => MonitorPostsThread(Monitoring, key, "modqueuespam", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPostsThread(Monitoring, key, "modqueuespam", subKey, startDelayMs, monitoringDelayMs)), options);
                 case "ModQueueUnmoderatedPosts":
-                    return new Thread(() => MonitorPostsThread(Monitoring, key, "modqueueunmoderated", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPostsThread(Monitoring, key, "modqueueunmoderated", subKey, startDelayMs, monitoringDelayMs)), options);
                 case "ModQueueEditedPosts":
-                    return new Thread(() => MonitorPostsThread(Monitoring, key, "modqueueedited", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPostsThread(Monitoring, key, "modqueueedited", subKey, startDelayMs, monitoringDelayMs)), options);
             }
         }
 

--- a/src/Reddit.NET/Controllers/User.cs
+++ b/src/Reddit.NET/Controllers/User.cs
@@ -1484,7 +1484,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "posts");
 
             string key = "PostHistory";
-            return Monitor(key, new Thread(() => MonitorPostHistoryThread(key, monitoringDelayMs)), Fullname);
+            return Monitor(key, new ThreadWrapper(new Thread(() => MonitorPostHistoryThread(key, monitoringDelayMs))), Fullname);
         }
 
         private void MonitorPostHistoryThread(string key, int? monitoringDelayMs = null, bool? breakOnFailure = null)
@@ -1533,7 +1533,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "comments");
 
             string key = "CommentHistory";
-            return Monitor(key, new Thread(() => MonitorCommentHistoryThread(key, monitoringDelayMs)), Fullname);
+            return Monitor(key, new ThreadWrapper(new Thread(() => MonitorCommentHistoryThread(key, monitoringDelayMs))), Fullname);
         }
 
         private void MonitorCommentHistoryThread(string key, int? monitoringDelayMs = null, bool? breakOnFailure = null)
@@ -1661,17 +1661,19 @@ namespace Reddit.Controllers
         /// <param name="subKey">Monitoring subKey</param>
         /// <param name="startDelayMs">How long to wait before starting the thread in milliseconds (default: 0)</param>
         /// <param name="monitoringDelayMs">How long to wait between monitoring queries; pass null to leave it auto-managed (default: null)</param>
+        /// <param name="options">The implementation-specific options</param>
         /// <returns>The newly-created monitoring thread.</returns>
-        protected override Thread CreateMonitoringThread(string key, string subKey, int startDelayMs = 0, int? monitoringDelayMs = null)
+        protected override ThreadWrapper CreateMonitoringThread(string key, string subKey, int startDelayMs = 0,
+            int? monitoringDelayMs = null, object options = null)
         {
             switch (key)
             {
                 default:
                     throw new RedditControllerException("Unrecognized key.");
                 case "PostHistory":
-                    return new Thread(() => MonitorHistoryThread(Monitoring, key, "posts", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorHistoryThread(Monitoring, key, "posts", subKey, startDelayMs, monitoringDelayMs)),options);
                 case "CommentHistory":
-                    return new Thread(() => MonitorHistoryThread(Monitoring, key, "comments", subKey, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorHistoryThread(Monitoring, key, "comments", subKey, startDelayMs, monitoringDelayMs)),options);
             }
         }
     }

--- a/src/Reddit.NET/Controllers/Wiki.cs
+++ b/src/Reddit.NET/Controllers/Wiki.cs
@@ -250,7 +250,7 @@ namespace Reddit.Controllers
             InitMonitoringCache(useCache, "pages");
 
             string key = "WikiPages";
-            return Monitor(key, new Thread(() => MonitorPagesThread(key, monitoringDelayMs: monitoringDelayMs)), Subreddit);
+            return Monitor(key, new ThreadWrapper(new Thread(() => MonitorPagesThread(key, monitoringDelayMs: monitoringDelayMs))), Subreddit);
         }
 
         /// <summary>
@@ -269,15 +269,17 @@ namespace Reddit.Controllers
         /// <param name="subKey">Monitoring subKey</param>
         /// <param name="startDelayMs">How long to wait before starting the thread in milliseconds (default: 0)</param>
         /// <param name="monitoringDelayMs">How long to wait between monitoring queries; pass null to leave it auto-managed (default: null)</param>
+        /// <param name="options">The implementation-specific options</param>
         /// <returns>The newly-created monitoring thread.</returns>
-        protected override Thread CreateMonitoringThread(string key, string subKey, int startDelayMs = 0, int? monitoringDelayMs = null)
+        protected override ThreadWrapper CreateMonitoringThread(string key, string subKey, int startDelayMs = 0,
+            int? monitoringDelayMs = null, object options = null)
         {
             switch (key)
             {
                 default:
                     throw new RedditControllerException("Unrecognized key.");
                 case "WikiPages":
-                    return new Thread(() => MonitorPagesThread(key, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPagesThread(key, startDelayMs, monitoringDelayMs)),options);
             }
         }
         

--- a/src/Reddit.NET/Controllers/WikiPage.cs
+++ b/src/Reddit.NET/Controllers/WikiPage.cs
@@ -490,7 +490,7 @@ namespace Reddit.Controllers
             }
 
             string key = "WikiPage";
-            return Monitor(key, new Thread(() => MonitorPageThread(key, monitoringDelayMs: monitoringDelayMs)), Name);
+            return Monitor(key, new ThreadWrapper(new Thread(() => MonitorPageThread(key, monitoringDelayMs: monitoringDelayMs))), Name);
         }
 
         /// <summary>
@@ -509,15 +509,17 @@ namespace Reddit.Controllers
         /// <param name="subKey">Monitoring subKey</param>
         /// <param name="startDelayMs">How long to wait before starting the thread in milliseconds (default: 0)</param>
         /// <param name="monitoringDelayMs">How long to wait between monitoring queries; pass null to leave it auto-managed (default: null)</param>
+        /// <param name="options">The implementation-specific options</param>
         /// <returns>The newly-created monitoring thread.</returns>
-        protected override Thread CreateMonitoringThread(string key, string subKey, int startDelayMs = 0, int? monitoringDelayMs = null)
+        protected override ThreadWrapper CreateMonitoringThread(string key, string subKey, int startDelayMs = 0,
+            int? monitoringDelayMs = null, object options = null)
         {
             switch (key)
             {
                 default:
                     throw new RedditControllerException("Unrecognized key.");
                 case "WikiPage":
-                    return new Thread(() => MonitorPageThread(key, startDelayMs, monitoringDelayMs));
+                    return new ThreadWrapper(new Thread(() => MonitorPageThread(key, startDelayMs, monitoringDelayMs)),options);
             }
         }
 


### PR DESCRIPTION
Previously, there was no way to pass custom fetching settings for monitoring. This update allows you to pass options to comment monitoring to suit it to your needs (e.g. bumping the limit from 25 to 100). It supports all of the settings the various `GetX` methods implement. 

To make this change, I modified the internal `Monitors` class to utilize a `TheadWrapper` class instead of the `Thread` class directly. This allows the inheriting classes the pass an `object` to the `CreateMonitoringThread` method to pass along options to various worker methods.

So far, I've only implemented monitoring options for comments.

