### PR TITLE
fix: initialize modmail cache

### DIFF
--- a/src/Reddit.NET/Controllers/Modmail.cs
+++ b/src/Reddit.NET/Controllers/Modmail.cs
@@ -150,7 +150,7 @@ namespace Reddit.Controllers
         internal override bool BreakOnFailure { get; set; }
         internal override List<MonitoringSchedule> MonitoringSchedule { get; set; }
         internal override DateTime? MonitoringExpiration { get; set; }
-        internal override HashSet<string> UseCache { get; set; }
+        internal override HashSet<string> UseCache { get; set; } = new HashSet<string>();
 
         private Dispatch Dispatch;
 

--- a/src/Reddit.NET/Reddit.NET.csproj
+++ b/src/Reddit.NET/Reddit.NET.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.5.0+develop</Version>
-    <AssemblyVersion>1.5.0.1</AssemblyVersion>
-    <FileVersion>1.5.0.1</FileVersion>
+    <Version>1.5.1+develop</Version>
+    <AssemblyVersion>1.5.1.1</AssemblyVersion>
+    <FileVersion>1.5.1.1</FileVersion>
     <PackageReleaseNotes>https://www.reddit.com/r/redditdev/comments/lkmlw7/announcing_the_release_of_redditnet_15/</PackageReleaseNotes>
     <Title>Reddit.NET</Title>
     <PackageId>Reddit</PackageId>


### PR DESCRIPTION
This resolves a null reference exception I was receiving when trying to monitor unread modmail on `1.5.0`. It looks like this is a bug from the code introduced as part of #117 - all other controllers initialize `UseCache` except `Modmail`.

```
System.NullReferenceException
  HResult=0x80004003
  Message=Object reference not set to an instance of an object.
  Source=Reddit.NET
  StackTrace:
   at Reddit.Controllers.Internal.Monitors.InitMonitoringCache(Boolean useCache, String type)

```